### PR TITLE
Expand the API surface of flowmailer-csharp

### DIFF
--- a/src/lib/Flowmailer/FlowmailerClient.cs
+++ b/src/lib/Flowmailer/FlowmailerClient.cs
@@ -117,15 +117,6 @@ namespace Flowmailer
             return request;
         }
 
-        private IRestRequest CreateSimulateSendMessageRequest(SubmitMessage message)
-        {
-            var request = CreateRequest(Method.POST, $"messages/simulate");
-
-            request.AddJsonBody(message);
-
-            return request;
-        }
-
         private async Task<List<MessageEvent>> GetMessageEventsDoAsync(DateTime from, DateTime to, int numberOfItems = 300)
         {
             var result = new List<MessageEvent>();

--- a/src/lib/Flowmailer/FlowmailerClient.cs
+++ b/src/lib/Flowmailer/FlowmailerClient.cs
@@ -21,13 +21,6 @@ namespace Flowmailer
         Task<string> SendMessageAsync(SubmitMessage message);
 
         /// <summary>
-        /// Simulates sending a message
-        /// </summary>
-        /// <param name="message"></param>
-        /// <returns></returns>
-        Task<string> SimulateSendMessageAsync(SubmitMessage message);
-
-        /// <summary>
         /// Sends a message.
         /// </summary>
         /// <param name="message"></param>
@@ -73,16 +66,6 @@ namespace Flowmailer
         public async Task<string> SendMessageAsync(SubmitMessage message)
         {
             return await DoRequestAsync(CreateSendMessageRequest(message), GetMessageId);
-        }
-
-        /// <summary>
-        /// Simulates sending a message
-        /// </summary>
-        /// <param name="message"></param>
-        /// <returns>MessageId as <see cref="string"/></returns>
-        public async Task<string> SimulateSendMessageAsync(SubmitMessage message)
-        {
-            return await DoRequestAsync(CreateSimulateSendMessageRequest(message), GetMessageId);
         }
 
         /// <summary>

--- a/src/lib/Flowmailer/FlowmailerClient.cs
+++ b/src/lib/Flowmailer/FlowmailerClient.cs
@@ -21,6 +21,13 @@ namespace Flowmailer
         Task<string> SendMessageAsync(SubmitMessage message);
 
         /// <summary>
+        /// Simulates sending a message
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        Task<string> SimulateSendMessageAsync(SubmitMessage message);
+
+        /// <summary>
         /// Sends a message.
         /// </summary>
         /// <param name="message"></param>
@@ -69,6 +76,16 @@ namespace Flowmailer
         }
 
         /// <summary>
+        /// Simulates sending a message
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns>MessageId as <see cref="string"/></returns>
+        public async Task<string> SimulateSendMessageAsync(SubmitMessage message)
+        {
+            return await DoRequestAsync(CreateSimulateSendMessageRequest(message), GetMessageId);
+        }
+
+        /// <summary>
         /// Sends a message.
         /// </summary>
         /// <param name="message"></param>
@@ -111,6 +128,15 @@ namespace Flowmailer
         private IRestRequest CreateSendMessageRequest(SubmitMessage message)
         {
             var request = CreateRequest(Method.POST, $"messages/submit");
+
+            request.AddJsonBody(message);
+
+            return request;
+        }
+
+        private IRestRequest CreateSimulateSendMessageRequest(SubmitMessage message)
+        {
+            var request = CreateRequest(Method.POST, $"messages/simulate");
 
             request.AddJsonBody(message);
 

--- a/src/lib/Flowmailer/Models/Attachment.cs
+++ b/src/lib/Flowmailer/Models/Attachment.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Flowmailer.Models
+{
+    public class Attachment
+    {
+        /// <summary>
+        /// Content as Bas64
+        /// </summary>
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Content-ID header (required for disposition related)
+        /// </summary>
+        public string ContentId { get; set; }
+
+        /// <summary>
+        /// MIME type of the content
+        /// Examples: application/pdf, image/jpeg
+        /// </summary>
+        public string ContentType { get; set; }
+
+        /// <summary>
+        /// Content-Disposition header for the attachment.
+        /// Supported values include: attachment, inline and related
+        /// The type of disposition, <see cref="DispositionTypes"/>
+        /// </summary>
+        public string ContentDisposition { get; set; }
+
+        /// <summary>
+        /// The filename
+        /// </summary>
+        public string Filename { get; set; }
+    }
+}

--- a/src/lib/Flowmailer/Models/DeliveryNotificationTypes.cs
+++ b/src/lib/Flowmailer/Models/DeliveryNotificationTypes.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Flowmailer.Models
+{
+    public static class DeliveryNotificationTypes
+    {
+        public static string None = "NONE";
+
+        public static string Failure = "FAILURE";
+
+        public static string DeliveryAndFailure = "DELIVERY_AND_FAILURE";
+    }
+}

--- a/src/lib/Flowmailer/Models/DispositionTypes.cs
+++ b/src/lib/Flowmailer/Models/DispositionTypes.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Flowmailer.Models
+{
+    public static class DispositionTypes
+    {
+        public static string Attachment = "attachment";
+        public static string Inline = "inline";
+        public static string Related = "related";
+    }
+}

--- a/src/lib/Flowmailer/Models/MessageTypes.cs
+++ b/src/lib/Flowmailer/Models/MessageTypes.cs
@@ -5,5 +5,7 @@ namespace Flowmailer.Models
     public static class MessageTypes
     {
         public const string EMAIL = "EMAIL";
+
+        public const string SMS = "SMS";
     }
 }

--- a/src/lib/Flowmailer/Models/SubmitMessage.cs
+++ b/src/lib/Flowmailer/Models/SubmitMessage.cs
@@ -72,9 +72,5 @@ namespace Flowmailer.Models
         /// Text content
         /// </summary>
         public string Text { get; set; }
-        /// <summary>
-        /// Source Id, required when using simulate message
-        /// </summary>
-        public string SourceId { get; set; }
     }
 }

--- a/src/lib/Flowmailer/Models/SubmitMessage.cs
+++ b/src/lib/Flowmailer/Models/SubmitMessage.cs
@@ -71,6 +71,10 @@ namespace Flowmailer.Models
         /// <summary>
         /// Text content
         /// </summary>
-        public string Text { get; set; }        
+        public string Text { get; set; }
+        /// <summary>
+        /// Source Id, required when using simulate message
+        /// </summary>
+        public string SourceId { get; set; }
     }
 }

--- a/src/lib/Flowmailer/Models/SubmitMessage.cs
+++ b/src/lib/Flowmailer/Models/SubmitMessage.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Flowmailer.Models
 {
@@ -8,9 +9,21 @@ namespace Flowmailer.Models
     public class SubmitMessage
     {
         /// <summary>
+        /// Attachments
+        /// </summary>
+        public Attachment[] Attachments { get; set; }
+        /// <summary>
         /// Collection of variables to send along the message
         /// </summary>
         public Dictionary<string, string> Data { get; set; }
+        /// <summary>
+        /// The delivery notification type, <see cref="DeliveryNotificationTypes"/>
+        /// </summary>
+        public string DeliveryNotificationType { get; set; }
+        /// <summary>
+        /// Freely configurable value that can be used to select a flow or one of its variants.
+        /// </summary>
+        public string FlowSelector { get; set; }
         /// <summary>
         /// Header value for from address
         /// </summary>
@@ -28,6 +41,10 @@ namespace Flowmailer.Models
         /// </summary>
         public Header[] Headers { get; set; }
         /// <summary>
+        /// The raw html message
+        /// </summary>
+        public string Html { get; set; }
+        /// <summary>
         /// The type of message, <see cref="MessageTypes"/>
         /// </summary>
         public string MessageType { get; set; }
@@ -35,6 +52,10 @@ namespace Flowmailer.Models
         /// The recipient address
         /// </summary>
         public string RecipientAddress { get; set; }
+        /// <summary>
+        /// Scheduling datetime
+        /// </summary>
+        public DateTime ScheduleAt { get; set; }
         /// <summary>
         /// The sender address
         /// </summary>
@@ -44,18 +65,12 @@ namespace Flowmailer.Models
         /// </summary>
         public string Subject { get; set; }
         /// <summary>
-        /// The raw html message
+        /// Tags
         /// </summary>
-        public string Html { get; set; }
-
-        /// <summary>
-        /// Freely configurable value that can be used to select a flow or one of its variants.
-        /// </summary>
-        public string FlowSelector { get; set; }
-
+        public string[] Tags { get; set; }
         /// <summary>
         /// Text content
         /// </summary>
-        public string Text { get; set; }
+        public string Text { get; set; }        
     }
 }


### PR DESCRIPTION
Hello,

This merge requests adds 2 functionalities supported by the flowmailer API. 

1. message type SMS to be able to send SMS messages
2. add some missing properties on the SubmitMessage payload: tags, attachments, delivery notification type
